### PR TITLE
Remove W3Schools from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Dla osób zupełnie nowych w tematach webdeveloperki utworzyliśmy [krótki arty
 
 ## Zródła których z przedstawionych niżej powodów należy unikać lub zwyczajnie brać na nie poprawkę:
 
-* [W3Schools](https://www.w3schools.com/)
-  * (https://forum.pasja-informatyki.pl/34559/w3schools-nie-szerzmy-falszywej-propagandy)
-  * (http://gal.steinitz.com/blog/2013/07/21/why-w3schools-is-bad-for-the-internet/)
-  * (https://www.webkrytyk.pl/2017/10/29/w3schools-com/)
 * [Kursy programowania z kanału Pasja Informatyki](https://www.youtube.com/user/MiroslawZelent)
   * (https://forum.pasja-informatyki.pl/122259/co-jest-nie-tak-z-najnowszym-odcinkiem-kursu-miroslawa-zelenta)
   * (https://www.webkrytyk.pl/2015/02/28/wideokursy-1-kurs-js-i-css-miroslawa-zelenta/)


### PR DESCRIPTION
Second link about W3Schools links to site named "W3Fools" (actually, it's hyperlink to MDN)
![obraz](https://user-images.githubusercontent.com/27734421/50550340-0f5a7380-0c6f-11e9-934a-547d12566dd3.png)

Googling W3Fools led me to "w3fools.com". [Link for the lazy](https://www.w3fools.com/). It states clearly:

> When W3Fools was launched in 2011, the state of documentation for developers was poor. This site documented many content errors and issues with the W3Schools website. The Mozilla Developer Network was around but it did not have much support at the time.
> 
> **Today, W3Schools has largely resolved these issues and addressed the majority of the undersigned developers' concerns. For many beginners, W3Schools has structured tutorials and playgrounds that offer a decent learning experience. Do keep in mind: a more complete education will certainly include MDN and other reputable resources.**

Second paragraph discusses the fact that **W3Schools is site offering a decent learning experience.**, while document implicitly linking to this website is clearly not respecting it's value.

So either paragraph mentioning W3Schools or hyperlink to gal.steinitz.com shall be removed, because this document and linked website populate different opinion, and can lower user's experience while following learning guidelines mentioned in this repository.